### PR TITLE
Disable pylint check on abstract class instantiated due to upstream issue

### DIFF
--- a/backends/fs.py
+++ b/backends/fs.py
@@ -66,6 +66,7 @@ class FileSystem(StoreBase):
     def _write_to_file(self, filename, box):
         dotted_filename = str(filename).replace('/', '.')
         lockfile = f'{self.lock_path}/{dotted_filename}.lock'
+        # pylint: disable=abstract-class-instantiated
         lock = FileLock(lockfile)
         with lock:
             with open(filename, 'wb') as save_file:
@@ -74,6 +75,7 @@ class FileSystem(StoreBase):
     def _load_from_file(self, filename):
         dotted_filename = str(filename).replace('/', '.')
         lockfile = f'{self.lock_path}/{dotted_filename}.lock'
+        # pylint: disable=abstract-class-instantiated
         lock = FileLock(lockfile)
         with lock:
             try:


### PR DESCRIPTION
Fixes #3 

### Description of the change

Pylint is complaining of an abstract class instantiated (as described in issue #3). However, according to FileLock's upstream (https://github.com/tox-dev/py-filelock/issues/102), this is a pylint bug and FileLock will not disable its type checker. Instead of sticking FileLock dependency to 3.2.0 (which is the version prior to the introduction of type checker templates), IMHO it is better just to disable this pylint check.

### Release notes

N/A